### PR TITLE
The schema name changed from connect to salesforce in Herokuconnect

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -11,7 +11,7 @@ end
 
 
 class Contact < ActiveRecord::Base
-  self.table_name = 'connect.contact'
+  self.table_name = 'salesforce.contact'
 end
 
 get "/contacts" do


### PR DESCRIPTION
There are also changes needed in the support documentation, but the "connect.contact" table name doesn't work. You need "salesforce" now as the schema name, not "connect"