### PR TITLE
change dashboard url to redirect to app resources

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -20,11 +20,8 @@ end
 #end
 
 get "/create" do
-  CREATE_URL = 'https://connect.heroku.com/dashboard-next/create-connection'
+  dashboard_url = 'https://dashboard.heroku.com/'
   match = /(.*?)\.herokuapp\.com/.match(request.host)
-  if match && match[1]
-    redirect to(CREATE_URL + "?create=" + match[1])
-  else
-    redirect to(CREATE_URL)
-  end
+  dashboard_url << "apps/#{match[1]}/resources" if match && match[1]
+  redirect to(dashboard_url)
 end


### PR DESCRIPTION
The button to create a Connect connection no longer works: partly due to changes in the way the add-on works and partly because it doesn't support EU region apps.

Getting the Platform API involved just to handle this redirect seems like overkill - so could either remove the button completely or redirect to the app resources page in the Heroku dashboard from where the user can open the Connect add-on (which is what this PR does).

Will also need to update the getting started article to include the extra step [here](https://devcenter.heroku.com/articles/getting-started-with-heroku-and-connect-without-local-dev#use-heroku-connect-to-sync-with-salesforce).